### PR TITLE
upd: StateChange -> ControlEvent

### DIFF
--- a/demo/src/app/examples/01-example-one/example-one.component.ts
+++ b/demo/src/app/examples/01-example-one/example-one.component.ts
@@ -13,6 +13,6 @@ export class ExampleOneComponent implements OnInit {
   constructor() {}
 
   ngOnInit() {
-    this.controlA.changes.subscribe(this.controlB.source);
+    this.controlA.events.subscribe(this.controlB.source);
   }
 }

--- a/demo/src/app/examples/02-example-two/example-two.component.ts
+++ b/demo/src/app/examples/02-example-two/example-two.component.ts
@@ -13,7 +13,7 @@ export class ExampleTwoComponent implements OnInit {
   constructor() {}
 
   ngOnInit() {
-    this.controlA.changes.subscribe(this.controlB.source);
-    this.controlB.changes.subscribe(this.controlA.source);
+    this.controlA.events.subscribe(this.controlB.source);
+    this.controlB.events.subscribe(this.controlA.source);
   }
 }

--- a/demo/src/app/examples/03-example-three/example-three.component.html
+++ b/demo/src/app/examples/03-example-three/example-three.component.html
@@ -30,7 +30,7 @@
         }"
       />
 
-      <div *ngIf="controlA.touched && controlA.invalid" class="error">
+      <div *ngIf="controlA.changed && controlA.invalid" class="error">
         <p>controlA Errors:</p>
         <p>{{ controlA.errors | json }}</p>
       </div>

--- a/demo/src/app/examples/03.5-example-three-five/example-three-five.component.ts
+++ b/demo/src/app/examples/03.5-example-three-five/example-three-five.component.ts
@@ -77,7 +77,7 @@ export class ExampleThreeFiveComponent implements OnInit {
     //   and before then filtering out the `StateChange` because the `inputControl` has already
     //   processed it.
 
-    this.inputControl.changes
+    this.inputControl.events
       .pipe(
         map(state => {
           switch (state.type) {
@@ -94,7 +94,7 @@ export class ExampleThreeFiveComponent implements OnInit {
       )
       .subscribe(this.dateControl.source);
 
-    this.dateControl.changes
+    this.dateControl.events
       .pipe(
         map(state => {
           switch (state.type) {

--- a/demo/src/app/examples/04-example-four/example-four.component.html
+++ b/demo/src/app/examples/04-example-four/example-four.component.html
@@ -18,7 +18,7 @@
       <label> usernameControl </label>
       <input [ngFormControl]="usernameControl" />
 
-      <div *ngIf="usernameControl.invalid" class="error">
+      <div *ngIf="usernameControl.status === 'INVALID'" class="error">
         <p>usernameControl Errors:</p>
         <p>{{ usernameControl.errors | json }}</p>
       </div>

--- a/demo/src/app/examples/04-example-four/example-four.component.ts
+++ b/demo/src/app/examples/04-example-four/example-four.component.ts
@@ -1,7 +1,15 @@
 import { Component, OnInit, Injectable, Inject } from '@angular/core';
 import { FormControl } from 'reactive-forms-module2-proposal';
-import { interval } from 'rxjs';
-import { take, tap, debounceTime, switchMap, map } from 'rxjs/operators';
+import { interval, of, Observable, NEVER } from 'rxjs';
+import {
+  take,
+  tap,
+  debounceTime,
+  switchMap,
+  map,
+  filter,
+  pairwise,
+} from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -11,9 +19,10 @@ export class UserService {
 
   doesNameExist(_: string) {
     this.start = !this.start;
+    const payload = this.start;
 
     return interval(500).pipe(
-      map(() => ({ payload: this.start })),
+      map(() => ({ payload })),
       take(1),
     );
   }
@@ -33,24 +42,104 @@ export class ExampleFourComponent implements OnInit {
     private userService: UserService,
   ) {}
 
+  /**
+   * # Overview
+   *
+   * So the easy way of doing async validation is to simply observe
+   * a control's `value` changes and then begin async validation.
+   *
+   * For example:
+   *
+   * ```ts
+   * this.usernameControl
+   *  .observeChanges('value', { ignoreNoEmit: true })
+   *  .pipe(
+   *     tap(() => {
+   *       this.usernameControl.markPending(true, {
+   *         source: 'userService',
+   *       });
+   *     }),
+   *     debounceTime(500),
+   *     switchMap(value => this.userService.doesNameExist(value)),
+   *     tap(() =>
+   *       this.usernameControl.markPending(false, { source: 'userService' }),
+   *     ),
+   *   )
+   *   .subscribe(response => {
+   *     const errors = response.payload ? { userNameExists: true } : null;
+   *     this.usernameControl.setErrors(errors, {
+   *       source: 'userService',
+   *     });
+   *   });
+   * ```
+   *
+   * While this approach may be fine for most use cases, it has some
+   * limitations:
+   *
+   * 1. Async validation is being performed even if the synchronous
+   *    validators have found the value to be invalid.
+   * 2. The control's `value` state change event is being emitted before
+   *    any async validation services have had a chance to react.
+   *
+   *    This means that it's possible something subscribed to `value`
+   *    state changes could:
+   *
+   *      1. Receive the state change event.
+   *      2. Check if the control is valid and see that it is.
+   *      3. Check if the control is pending and see that it isn't.
+   *
+   *    All before any async services have had a chance to mark the control
+   *    as pending or invalid.
+   *
+   * If you want to ensure that any `value` state change events
+   * are only emitted after async services have had a chance to react
+   * (usually by synchronously marking the control as `pending`), then we need
+   * to subscribe to the "validation end" lifecycle event.
+   */
+
   ngOnInit() {
-    this.usernameControl
-      .observeChanges('value', { ignoreNoEmit: true })
+    this.usernameControl.events
       .pipe(
-        tap(() =>
-          this.usernameControl.markPending(true, { source: 'userService' }),
-        ),
-        debounceTime(500),
-        switchMap(value => this.userService.doesNameExist(value)),
-        tap(() =>
-          this.usernameControl.markPending(false, { source: 'userService' }),
-        ),
+        // Wait for the control to complete its synchronous validation.
+        filter(event => event.type === 'validation' && event.value === 'end'),
+        tap(() => {
+          // Discard any existing errors set by the userService as they are
+          // no longer applicable.
+          this.usernameControl.setErrors(null, {
+            source: `userService`,
+          });
+
+          // If the control is already marked invalid, we're going to skip the async
+          // validation check so don't bother to mark pending.
+          this.usernameControl.markPending(this.usernameControl.valid, {
+            source: `userService`,
+          });
+        }),
+        // By running validation inside a `switchMap` + `interval()` (instead
+        // of `debounceTime()`), we ensure that an in-progress async validation
+        // check is discarded if the user starts typing again.
+        switchMap(() => {
+          // If the control is already invalid we don't need to do anything.
+          if (this.usernameControl.invalid) return NEVER;
+
+          // Else run validation.
+          return interval(500).pipe(
+            take(1),
+            switchMap(() =>
+              this.userService.doesNameExist(this.usernameControl.value),
+            ),
+          );
+        }),
       )
       .subscribe(response => {
+        this.usernameControl.markPending(false, {
+          source: `userService`,
+        });
+
         const errors = response.payload ? { userNameExists: true } : null;
 
         this.usernameControl.setErrors(errors, {
-          source: 'MyUserService',
+          source: `userService`,
         });
       });
   }

--- a/demo/src/app/examples/05-example-five/my-control.directive.ts
+++ b/demo/src/app/examples/05-example-five/my-control.directive.ts
@@ -57,7 +57,7 @@ export class MyControlDirective implements OnChanges {
     // If the `validatorStore` of the control is ever reset,
     // re-add these validators
     this.subscriptions.push(
-      this.control.changes
+      this.control.events
         .pipe(filter(({ type }) => type === 'validatorStore'))
         .subscribe(() => {
           this.control.setValidators(this.validators, {

--- a/demo/src/app/examples/09-example-nine/example-nine.component.ts
+++ b/demo/src/app/examples/09-example-nine/example-nine.component.ts
@@ -9,7 +9,7 @@ import { filter } from 'rxjs/operators';
 })
 export class ExampleNineComponent implements OnInit {
   controlA = new FormControl('');
-  values$ = this.controlA.changes.pipe(filter(state => state.type === 'value'));
+  values$ = this.controlA.events.pipe(filter(state => state.type === 'value'));
 
   constructor() {}
 

--- a/demo/src/app/proposal-accessors/accessors/util.ts
+++ b/demo/src/app/proposal-accessors/accessors/util.ts
@@ -16,7 +16,7 @@ export function watchProp<T extends AbstractControl>(
   control: T,
   prop: keyof T,
 ) {
-  return control.changes.pipe(
+  return control.events.pipe(
     filter(({ type }) => type === prop),
     startWith(null),
     map(() => control[prop]),

--- a/libs/reactive-forms-module2-proposal/compat/src/lib/directives/ng_compat_form_control_directive.ts
+++ b/libs/reactive-forms-module2-proposal/compat/src/lib/directives/ng_compat_form_control_directive.ts
@@ -209,7 +209,7 @@ export class NgCompatFormControlDirective implements OnChanges, OnDestroy {
       .subscribe(this.control.source);
 
     this.subscriptions.push(
-      this.control.changes
+      this.control.events
         .pipe(
           filter(
             ({ type, meta }) =>
@@ -227,7 +227,7 @@ export class NgCompatFormControlDirective implements OnChanges, OnDestroy {
     );
 
     this.subscriptions.push(
-      this.control.changes
+      this.control.events
         .pipe(
           filter(state => {
             if (state.noEmit) {

--- a/libs/reactive-forms-module2-proposal/src/lib/accessors/default_value_accessor.ts
+++ b/libs/reactive-forms-module2-proposal/src/lib/accessors/default_value_accessor.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/core';
 import { ɵgetDOM as getDOM } from '@angular/platform-browser';
 import { distinctUntilChanged } from 'rxjs/operators';
-import { setupListeners, watchProp } from './util';
+import { setupListeners } from './util';
 import { FormControl } from '../models';
 import { NG_CONTROL_ACCESSOR, ControlAccessor } from './interface';
 
@@ -94,16 +94,19 @@ export class DefaultValueAccessor implements ControlAccessor {
       this._compositionMode = !_isAndroid();
     }
 
-    watchProp(this.control, 'value').subscribe((value: any) => {
-      const normalizedValue = value == null ? '' : value;
-      this.renderer.setProperty(
-        this.el.nativeElement,
-        'value',
-        normalizedValue,
-      );
-    });
+    this.control
+      .observe('value', { ignoreNoEmit: true })
+      .subscribe((value: any) => {
+        const normalizedValue = value == null ? '' : value;
+        this.renderer.setProperty(
+          this.el.nativeElement,
+          'value',
+          normalizedValue,
+        );
+      });
 
-    watchProp(this.control, 'disabled')
+    this.control
+      .observe('disabled', { ignoreNoEmit: true })
       .pipe(distinctUntilChanged())
       .subscribe(isDisabled => {
         this.renderer.setProperty(

--- a/libs/reactive-forms-module2-proposal/src/lib/accessors/util.ts
+++ b/libs/reactive-forms-module2-proposal/src/lib/accessors/util.ts
@@ -11,14 +11,3 @@ export function looseIdentical(a: any, b: any): boolean {
 export function setupListeners(dir: any, event: string, fn: string) {
   dir.renderer.listen(dir.el.nativeElement, event, dir[fn].bind(dir));
 }
-
-export function watchProp<T extends AbstractControl>(
-  control: T,
-  prop: keyof T,
-) {
-  return control.changes.pipe(
-    filter(({ type }) => type === prop),
-    startWith(null),
-    map(() => control[prop]),
-  );
-}

--- a/libs/reactive-forms-module2-proposal/src/lib/directives/control.directive.ts
+++ b/libs/reactive-forms-module2-proposal/src/lib/directives/control.directive.ts
@@ -1,0 +1,111 @@
+import { Input, OnDestroy, OnChanges, SimpleChange } from '@angular/core';
+import { AbstractControl } from '../models';
+import { ControlStateMapper, ControlValueMapper } from './interface';
+import { map, filter } from 'rxjs/operators';
+import { NgBaseDirective } from './base.directive';
+import { ControlAccessor } from '../accessors';
+
+export abstract class NgControlDirective<T extends AbstractControl>
+  extends NgBaseDirective<T>
+  implements ControlAccessor, OnChanges, OnDestroy {
+  @Input('ngFormControl') providedControl!: T;
+  @Input('ngFormControlStateMapper')
+  stateMapper?: ControlStateMapper;
+  @Input('ngFormControlValueMapper')
+  valueMapper?: ControlValueMapper;
+
+  abstract readonly control: T;
+
+  ngOnChanges(_: {
+    providedControl?: SimpleChange;
+    stateMapper?: SimpleChange;
+    valueMapper?: SimpleChange;
+  }) {
+    this.onChangesSubscriptions.forEach(sub => sub.unsubscribe());
+    this.onChangesSubscriptions = [];
+
+    this.control.emitEvent({
+      source: this.id,
+      type: 'ControlAccessor',
+      value: 'Cleanup',
+    });
+
+    this.control.emitEvent({
+      source: this.id,
+      type: 'ControlAccessor',
+      value: 'PreInit',
+    });
+
+    this.onChangesSubscriptions.push(
+      this.providedControl
+        .replayState({ includeDefaults: true })
+        .pipe(
+          filter(({ type }) => type !== 'validation'),
+          map(this.fromProvidedControlMapFn()),
+        )
+        .subscribe(this.control.source),
+      this.providedControl.events
+        .pipe(
+          filter(({ type }) => type !== 'validation'),
+          map(this.fromProvidedControlMapFn()),
+        )
+        .subscribe(this.control.source),
+    );
+
+    if (this.valueMapper && this.valueMapper.accessorValidator) {
+      const validator = this.valueMapper.accessorValidator;
+
+      this.control.setErrors(validator(this.control), {
+        source: this.id,
+      });
+
+      // validate the control via a service to avoid the possibility
+      // of the user somehow deleting our validator function.
+      this.onChangesSubscriptions.push(
+        this.control.events
+          .pipe(
+            filter(
+              ({ type, value, source }) =>
+                type === 'validation' &&
+                value === 'internalEnd' &&
+                source === this.control.id,
+            ),
+          )
+          .subscribe(() => {
+            this.control.setErrors(validator(this.control), {
+              source: this.id,
+            });
+          }),
+      );
+    } else {
+      this.control.setErrors(null, {
+        source: this.id,
+      });
+    }
+
+    this.onChangesSubscriptions.push(
+      this.control.events
+        .pipe(
+          filter(({ type }) => type !== 'validation'),
+          map(this.toProvidedControlMapFn()),
+        )
+        .subscribe(this.providedControl.source),
+    );
+
+    this.control.emitEvent({
+      source: this.id,
+      type: 'ControlAccessor',
+      value: 'PostInit',
+    });
+  }
+
+  ngOnDestroy() {
+    super.ngOnDestroy();
+
+    this.control.emitEvent({
+      source: this.id,
+      type: 'ControlAccessor',
+      value: 'Cleanup',
+    });
+  }
+}

--- a/libs/reactive-forms-module2-proposal/src/lib/directives/form-control.directive.ts
+++ b/libs/reactive-forms-module2-proposal/src/lib/directives/form-control.directive.ts
@@ -15,20 +15,15 @@ import { map, filter } from 'rxjs/operators';
 import { NgBaseDirective } from './base.directive';
 import { resolveControlAccessor } from './util';
 import { ControlAccessor, NG_CONTROL_ACCESSOR } from '../accessors';
+import { NgControlDirective } from './control.directive';
 
 @Directive({
   selector: '[ngFormControl]:not([formControl])',
   exportAs: 'ngForm',
 })
-export class NgFormControlDirective extends NgBaseDirective<AbstractControl>
+export class NgFormControlDirective extends NgControlDirective<FormControl>
   implements ControlAccessor, OnChanges, OnDestroy {
-  @Input('ngFormControl') providedControl!: AbstractControl;
-  @Input('ngFormControlStateMapper')
-  stateMapper?: ControlStateMapper;
-  @Input('ngFormControlValueMapper')
-  valueMapper?: ControlValueMapper;
-
-  readonly control = new FormControl<any>();
+  readonly control = new FormControl();
   readonly accessor: ControlAccessor;
 
   constructor(
@@ -45,9 +40,14 @@ export class NgFormControlDirective extends NgBaseDirective<AbstractControl>
     this.subscriptions.push(
       this.accessor.control
         .replayState({ includeDefaults: true })
+        .pipe(filter(({ type }) => type !== 'validation'))
         .subscribe(this.control.source),
-      this.accessor.control.changes.subscribe(this.control.source),
-      this.control.changes.subscribe(this.accessor.control.source),
+      this.accessor.control.events
+        .pipe(filter(({ type }) => type !== 'validation'))
+        .subscribe(this.control.source),
+      this.control.events
+        .pipe(filter(({ type }) => type !== 'validation'))
+        .subscribe(this.accessor.control.source),
     );
   }
 
@@ -60,73 +60,6 @@ export class NgFormControlDirective extends NgBaseDirective<AbstractControl>
       throw new Error(`NgFormControlDirective must be passed a ngFormControl`);
     }
 
-    this.onChangesSubscriptions.forEach(sub => sub.unsubscribe());
-    this.onChangesSubscriptions = [];
-
-    this.control.stateChange({
-      source: this.id,
-      type: 'ControlAccessor',
-      value: 'Cleanup',
-    });
-
-    this.control.stateChange({
-      source: this.id,
-      type: 'ControlAccessor',
-      value: 'PreInit',
-    });
-
-    this.onChangesSubscriptions.push(
-      this.providedControl
-        .replayState({ includeDefaults: true })
-        .pipe(map(this.fromProvidedControlMapFn()))
-        .subscribe(this.control.source),
-      this.providedControl.changes
-        .pipe(map(this.fromProvidedControlMapFn()))
-        .subscribe(this.control.source),
-    );
-
-    if (this.valueMapper && this.valueMapper.accessorValidator) {
-      const validator = this.valueMapper.accessorValidator;
-
-      this.control.setValidators(validator, {
-        source: this.id,
-      });
-
-      this.onChangesSubscriptions.push(
-        this.control.changes
-          .pipe(filter(({ type }) => type === 'validatorStore'))
-          .subscribe(() => {
-            this.control.setValidators(validator, {
-              source: this.id,
-            });
-          }),
-      );
-    } else {
-      this.control.setValidators(null, {
-        source: this.id,
-      });
-    }
-
-    this.onChangesSubscriptions.push(
-      this.control.changes
-        .pipe(map(this.toProvidedControlMapFn()))
-        .subscribe(this.providedControl.source),
-    );
-
-    this.control.stateChange({
-      source: this.id,
-      type: 'ControlAccessor',
-      value: 'PostInit',
-    });
-  }
-
-  ngOnDestroy() {
-    super.ngOnDestroy();
-
-    this.control.stateChange({
-      source: this.id,
-      type: 'ControlAccessor',
-      value: 'Cleanup',
-    });
+    super.ngOnChanges(_);
   }
 }

--- a/libs/reactive-forms-module2-proposal/src/lib/directives/form-group.directive.ts
+++ b/libs/reactive-forms-module2-proposal/src/lib/directives/form-group.directive.ts
@@ -22,6 +22,7 @@ import {
   NG_CONTROL_ACCESSOR,
   ControlAccessor,
 } from '../accessors';
+import { NgControlDirective } from './control.directive';
 
 @Directive({
   selector: '[ngFormGroup]',
@@ -33,14 +34,8 @@ import {
     },
   ],
 })
-export class NgFormGroupDirective extends NgBaseDirective<FormGroup>
-  implements ControlContainerAccessor<FormGroup>, OnChanges, OnDestroy {
-  @Input('ngFormGroup') providedControl!: FormGroup;
-  @Input('ngFormGroupStateMapper')
-  stateMapper?: ControlStateMapper;
-  @Input('ngFormGroupValueMapper')
-  valueMapper?: ControlValueMapper;
-
+export class NgFormGroupDirective extends NgControlDirective<FormGroup>
+  implements OnChanges {
   readonly control = new FormGroup();
   readonly accessor: ControlContainerAccessor | null;
 
@@ -60,9 +55,14 @@ export class NgFormGroupDirective extends NgBaseDirective<FormGroup>
       this.subscriptions.push(
         this.accessor.control
           .replayState({ includeDefaults: true })
+          .pipe(filter(({ type }) => type !== 'validation'))
           .subscribe(this.control.source),
-        this.accessor.control.changes.subscribe(this.control.source),
-        this.control.changes.subscribe(this.accessor.control.source),
+        this.accessor.control.events
+          .pipe(filter(({ type }) => type !== 'validation'))
+          .subscribe(this.control.source),
+        this.control.events
+          .pipe(filter(({ type }) => type !== 'validation'))
+          .subscribe(this.accessor.control.source),
       );
     }
   }
@@ -76,73 +76,6 @@ export class NgFormGroupDirective extends NgBaseDirective<FormGroup>
       throw new Error(`NgFormGroupDirective must be passed a ngFormGroup`);
     }
 
-    this.onChangesSubscriptions.forEach(sub => sub.unsubscribe());
-    this.onChangesSubscriptions = [];
-
-    this.control.stateChange({
-      source: this.id,
-      type: 'ControlAccessor',
-      value: 'Cleanup',
-    });
-
-    this.control.stateChange({
-      source: this.id,
-      type: 'ControlAccessor',
-      value: 'PreInit',
-    });
-
-    this.onChangesSubscriptions.push(
-      this.providedControl
-        .replayState({ includeDefaults: true })
-        .pipe(map(this.fromProvidedControlMapFn()))
-        .subscribe(this.control.source),
-      this.providedControl.changes
-        .pipe(map(this.fromProvidedControlMapFn()))
-        .subscribe(this.control.source),
-    );
-
-    if (this.valueMapper && this.valueMapper.accessorValidator) {
-      const validator = this.valueMapper.accessorValidator;
-
-      this.control.setValidators(validator, {
-        source: this.id,
-      });
-
-      this.onChangesSubscriptions.push(
-        this.control.changes
-          .pipe(filter(({ type }) => type === 'validatorStore'))
-          .subscribe(() => {
-            this.control.setValidators(validator, {
-              source: this.id,
-            });
-          }),
-      );
-    } else {
-      this.control.setValidators(null, {
-        source: this.id,
-      });
-    }
-
-    this.onChangesSubscriptions.push(
-      this.control.changes
-        .pipe(map(this.toProvidedControlMapFn()))
-        .subscribe(this.providedControl.source),
-    );
-
-    this.control.stateChange({
-      source: this.id,
-      type: 'ControlAccessor',
-      value: 'PostInit',
-    });
-  }
-
-  ngOnDestroy() {
-    super.ngOnDestroy();
-
-    this.control.stateChange({
-      source: this.id,
-      type: 'ControlAccessor',
-      value: 'Cleanup',
-    });
+    super.ngOnChanges(_);
   }
 }

--- a/libs/reactive-forms-module2-proposal/src/lib/directives/interface.ts
+++ b/libs/reactive-forms-module2-proposal/src/lib/directives/interface.ts
@@ -1,8 +1,8 @@
-import { StateChange, ValidatorFn } from '../models';
+import { ControlEvent, ValidatorFn } from '../models';
 
 export interface ControlStateMapper {
-  fromControl: (state: StateChange<string, any>) => StateChange<string, any>;
-  toControl: (state: StateChange<string, any>) => StateChange<string, any>;
+  fromControl: (state: ControlEvent<string, any>) => ControlEvent<string, any>;
+  toControl: (state: ControlEvent<string, any>) => ControlEvent<string, any>;
 }
 
 export interface ControlValueMapper<ControlValue = any, NewValue = any> {

--- a/libs/reactive-forms-module2-proposal/src/lib/models/control-container-base.ts
+++ b/libs/reactive-forms-module2-proposal/src/lib/models/control-container-base.ts
@@ -3,8 +3,8 @@ import { FormControl as _FormControl } from '@angular/forms';
 import { map } from 'rxjs/operators';
 import {
   AbstractControl,
-  StateChange,
-  StateChangeOptions,
+  ControlEvent,
+  ControlEventOptions,
 } from './abstract-control';
 import { ControlContainer } from './control-container';
 import { ControlBase, IControlBaseArgs } from './control-base';
@@ -44,7 +44,7 @@ export abstract class ControlContainerBase<C, V, D> extends ControlBase<V, D>
     );
   }
 
-  setValue(value: V, options: StateChangeOptions = {}) {
+  setValue(value: V, options: ControlEventOptions = {}) {
     this.validateValueShape(value);
 
     super.setValue(value, options);
@@ -56,18 +56,18 @@ export abstract class ControlContainerBase<C, V, D> extends ControlBase<V, D>
 
   abstract removeControl(...args: any[]): void;
 
-  abstract markAllTouched(value: boolean, options?: StateChangeOptions): void;
+  abstract markAllTouched(value: boolean, options?: ControlEventOptions): void;
 
   replayState(
-    options: StateChangeOptions & { includeDefaults?: boolean } = {},
+    options: ControlEventOptions & { includeDefaults?: boolean } = {},
   ) {
-    const state: StateChange<string, any>[] = [
-      this.buildStateChange('controls', this.controls, options),
+    const state: ControlEvent<string, any>[] = [
+      this.buildEvent('controls', this.controls, options),
     ];
 
     if (options.includeDefaults) {
       state.push(
-        this.buildStateChange(
+        this.buildEvent(
           'controlsDefault',
           this._controlsDefault,
           options,

--- a/libs/reactive-forms-module2-proposal/src/lib/models/control-container.ts
+++ b/libs/reactive-forms-module2-proposal/src/lib/models/control-container.ts
@@ -1,4 +1,4 @@
-import { AbstractControl, StateChangeOptions } from './abstract-control';
+import { AbstractControl, ControlEventOptions } from './abstract-control';
 
 export type ControlContainerControls<T> = T extends ControlContainer<infer C>
   ? C
@@ -37,5 +37,5 @@ export abstract class ControlContainer<
 
   abstract removeControl(...args: any[]): void;
 
-  abstract markAllTouched(value: boolean, options?: StateChangeOptions): void;
+  abstract markAllTouched(value: boolean, options?: ControlEventOptions): void;
 }


### PR DESCRIPTION
This renames the api from "the StateChange API" to "the ControlEvent API". To accompany this change the `changes` property was renamed to `events`, as well as numerous other small changes as appropriate.

This change was made to better reflect what the StateChange API had become: an API for all sorts of events related to an AbstractControl (including stateChange) events. Now, ControlEvent objects which represent state changes have a `stateChange: true` property.